### PR TITLE
Fix problem with Cucumber 4 - no method "feature" found

### DIFF
--- a/config/initializers/cucumber.rb
+++ b/config/initializers/cucumber.rb
@@ -1,0 +1,10 @@
+# Based on https://github.com/cucumber/cucumber-ruby/issues/1432
+# HACK: this method was available in cucumber 3.1 and VCR relies on it to
+# generate cassette names.
+Cucumber::Core::Test::Case.class_eval do
+  def feature
+    string = File.read(location.file)
+    document = ::Gherkin::Parser.new.parse(string)
+    document[:feature]
+  end
+end

--- a/features/support/vcr.rb
+++ b/features/support/vcr.rb
@@ -5,7 +5,7 @@ VCR.configure do |c|
   c.cassette_library_dir = 'features/support/fixtures/cassettes'
   c.ignore_localhost = true
   c.default_cassette_options = {
-    :match_requests_on => [
+    match_requests_on: [
         :method,
         VCR.request_matchers.uri_without_param(:imp, :prev_imp, :distinct_id)
     ]
@@ -20,5 +20,5 @@ VCR.configure do |c|
 end
 
 VCR.cucumber_tags do |t|
-  t.tag '@vcr', :use_scenario_name => true
+  t.tag '@vcr', use_scenario_name: true
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ require 'capybara-screenshot/rspec'
 require 'public_activity/testing'
 require 'paper_trail/frameworks/rspec'
 require 'selenium/webdriver'
+require 'pry-byebug'
 
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 PublicActivity.enabled = true


### PR DESCRIPTION
Cucumber 4 introduced some change incompatible with current version of VCR. There is no official fix for this incompatibility. The workaround was mentioned both on the Cucumber and VCR side (same guy) - https://github.com/cucumber/cucumber-ruby/issues/1432 and https://github.com/vcr/vcr/issues/825

I'm adding the missing method with the class_eval.

Additionally, I've added `pry-byebug` to the `rails_helper` and fixed lint issue in another place.